### PR TITLE
Rebuild shap 0.39.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,9 +46,6 @@ test:
     - shap
     - shap.explainers
     - shap.explainers.other
-    - shap.explainers._deep
-    - shap.plots 
-    - shap.plots.colors
     - shap.benchmark
     - shap.maskers
     - shap.utils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,9 @@ requirements:
     - make  # [unix]
   host:
     - python
-    - numpy
     - pip
     - setuptools
+    - numpy
   run:
     - python
     - numpy
@@ -39,7 +39,6 @@ requirements:
 
 test:
   requires:
-    - matplotlib-base
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,8 @@ source:
   sha256: 745ff59246c517e13fb29c700c12ee78c1d833078f667676615c11cfdc244c9c
 
 build:
-  number: 1
-  # numba currently isn't available on s390x
-  skip: True  # [s390x]
+  number: 0
+  # trigger 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   missing_dso_whitelist:  # [win]
    - $RPATH/cudart64_101.dll  # [win]
@@ -26,7 +25,6 @@ requirements:
     - numpy
     - pip
     - setuptools
-    - wheel
   run:
     - python
     - numpy
@@ -47,13 +45,6 @@ test:
     - pip check
   imports:
     - shap
-    - shap.explainers
-    - shap.explainers.other
-    - shap.benchmark
-    - shap.maskers
-    - shap.utils
-    - shap.actions
-    - shap.models
 
 about:
   home: https://github.com/slundberg/shap

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 745ff59246c517e13fb29c700c12ee78c1d833078f667676615c11cfdc244c9c
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   missing_dso_whitelist:  # [win]
    - $RPATH/cudart64_101.dll  # [win]
@@ -21,9 +21,10 @@ requirements:
     - make  # [unix]
   host:
     - python
+    - numpy
     - pip
     - setuptools
-    - numpy
+    - wheel
   run:
     - python
     - numpy
@@ -43,6 +44,16 @@ test:
     - pip check
   imports:
     - shap
+    - shap.explainers
+    - shap.explainers.other
+    - shap.explainers._deep
+    - shap.plots 
+    - shap.plots.colors
+    - shap.benchmark
+    - shap.maskers
+    - shap.utils
+    - shap.actions
+    - shap.models
 
 about:
   home: https://github.com/slundberg/shap

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
 
 test:
   requires:
+    - matplotlib-base
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 1
+  # numba currently isn't available on s390x
+  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   missing_dso_whitelist:  # [win]
    - $RPATH/cudart64_101.dll  # [win]


### PR DESCRIPTION
Rebuild shap 0.39.0 for py38 on win-64

Bug Tracker: new open issues https://github.com/slundberg/shap/issues
Upstream license:  License file:  https://github.com/slundberg/shap/blob/master/LICENSE
Upstream setup.py:  https://github.com/slundberg/shap/blob/v0.39.0/setup.py

No changes