### PR TITLE
Update to v 0.42.1:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - scipy
     - scikit-learn
     - pandas
-    - tqdm >4.27.0
+    - tqdm >=4.27.0
     - packaging >20.9
     - slicer 0.0.7
     - numba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set author = "slundberg" %}
 {% set name = "shap" %}
-{% set version = "0.41.0" %}
-{% set sha256 = "ce5117e7921f47128b529cffa0a5e7ad3f0ebcdc6d0ae57e929385bf49fb68f6" %}
+{% set version = "0.42.1" %}
+{% set sha256 = "3cba8049c36b41c2319270ab62e1d54135b7a6d76705cffbda3c6067aacadb29" %}
 
 package:
   name: {{ name|lower }}
@@ -12,11 +12,11 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vv
   missing_dso_whitelist:  # [win]
    - $RPATH/cudart64_101.dll  # [win]
-  skip: true # [s390x]
+  skip: true # [py<37 or s390x]
 
 requirements:
   build:
@@ -28,13 +28,14 @@ requirements:
     - setuptools
     - wheel
     - numpy {{ numpy }}
+    - packaging >20.9
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-learn
     - pandas
-    - tqdm >4.25.0
+    - tqdm >4.27.0
     - packaging >20.9
     - slicer 0.0.7
     - numba


### PR DESCRIPTION
Upstream: https://github.com/shap/shap/tree/v0.42.1
Conda-forge: https://github.com/conda-forge/shap-feedstock/blob/main/recipe/meta.yaml
Jira: [PKG-2645]

 - Current shap, when used together with numpy >1.20, may fail cause it uses numpy.bool which has been deprecated with version 1.20. It seems nothing really uses shap except for the package interpret, currently in the works. It was decided to update shap to the latest version which does not have this problem with the new numpy versions anymore.
 - Build number has been reset to 0, deps updated.
 - I really wanted to add pytests to this recipe but it requires some test dependencies we do not have, the main one being pytest-mpl. Also, tensorflow conflicts with specified protobuf. Hence shap will be tested as part of interpret (Have already tested locally and the problem is resolved).

[PKG-2645]: https://anaconda.atlassian.net/browse/PKG-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ