### PR TITLE
shap 0.46.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/slicer-feedstock/pr1/5255ae5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/slicer-feedstock/pr1/5255ae5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,7 +105,7 @@ about:
     uniting several previous methods and representing the only possible consistent and
     locally accurate additive feature attribution method based on expectations.
   doc_url: https://shap.readthedocs.io
-  dev_url: https://github.com/slundberg/shap
+  dev_url: https://github.com/shap/shap
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,34 +1,32 @@
-{% set author = "slundberg" %}
 {% set name = "shap" %}
-{% set version = "0.42.1" %}
-{% set sha256 = "3cba8049c36b41c2319270ab62e1d54135b7a6d76705cffbda3c6067aacadb29" %}
+{% set version = "0.46.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ author }}/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bdaa5b098be5a958348015e940f6fd264339b5db1e651f9898a3117be95b05a0
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vv
-  missing_dso_whitelist:  # [win]
-   - $RPATH/cudart64_101.dll  # [win]
-  skip: true # [py<37 or s390x]
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - make  # [unix]
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=61.0
+    - setuptools-scm >=8.0
+    - packaging >=20.9
     - wheel
-    - numpy {{ numpy }}
-    - packaging >20.9
+    - numpy >=2.0
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -37,23 +35,50 @@ requirements:
     - pandas
     - tqdm >=4.27.0
     - packaging >20.9
-    - slicer 0.0.7
+    - slicer ==0.0.8
     - numba
     - cloudpickle
 
 test:
   requires:
     - pip
-    - matplotlib
+    - pytest
+    # pytest-mpl not available
+    # - pytest-mpl
+    - matplotlib-base
+    - ipython
+    - xgboost
+    - tensorflow  # [linux64 and py<312]
+    # Not available on the platforms
+    - pytorch  # [not win]
+    # transformers tests require pytorch
+    - transformers  # [not win]
+    - catboost
+    # ngboost not available
+    # - ngboost
+    - pyod >=1
+    # Fails tests/explainers/test_tree.py::test_skopt_rf_et
+    # - scikit-optimize
+    # Rebuild for osx-arm64?
+    # - gpboost
+    - lightgbm
+    # Due to old pins on tensorflow, this would downgrade tensorflow massively
+    # - opencv
+    - sentencepiece
+  source_files:
+    - tests
   commands:
     - pip check
+    - pytest -sv tests --ignore=tests/benchmark --ignore=tests/maskers/test_text.py -k "not (test_fixed_composite_masker_call)"
   imports:
     - shap
+    - shap.cext
     - shap.explainers
     - shap.explainers.other
     - shap.explainers._deep
     - shap.plots
     - shap.plots.colors
+    - shap.plots.resources
     - shap.benchmark
     - shap.maskers
     - shap.utils
@@ -68,14 +93,17 @@ about:
   summary: A unified approach to explain the output of any machine learning model.
   description: |
     SHAP (SHapley Additive exPlanations) is a unified approach to explain the output
-    of any machine learning model. SHAP connects game theory with local explanations, 
-    uniting several previous methods and representing the only possible consistent 
-    and locally accurate additive feature attribution method based on expectations.
-  doc_url: https://shap.readthedocs.io/en/latest/
+    of any machine learning model. SHAP connects game theory with local explanations,
+    uniting several previous methods and representing the only possible consistent and
+    locally accurate additive feature attribution method based on expectations.
+  doc_url: https://shap.readthedocs.io
   dev_url: https://github.com/slundberg/shap
 
 extra:
   recipe-maintainers:
+    - connortann
     - mrandrewandrade
+    - primozgodec
     - slundberg
     - xhochy
+  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make  # [unix]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - numpy >=2.0
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - scipy
     - scikit-learn
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,7 @@ test:
     - tests
   commands:
     - pip check
-    - pytest -sv tests --ignore=tests/benchmark --ignore=tests/maskers/test_text.py -k "not (test_fixed_composite_masker_call)"
+    - pytest -sv tests --ignore=tests/benchmark
   imports:
     - shap
     - shap.cext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,10 @@ requirements:
     - setuptools-scm >=8.0
     - packaging >=20.9
     - wheel
-    - numpy >=2.0
+    - numpy {{ numpy }}
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-learn
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,9 @@ test:
     - tests
   commands:
     - pip check
+    # OMP: Error #13: Assertion failure at kmp_dispatch.cpp(1298).
+    # https://github.com/llvm/llvm-project/issues/54422
+    - export OMP_NUM_THREADS=1  # [osx]
     - pytest -sv tests --ignore=tests/benchmark
   imports:
     - shap

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,8 @@ test:
     - matplotlib-base
     - ipython
     - xgboost
-    - tensorflow  # [linux64 and py<312]
+    # tensorflow makes pip check to fail
+    # - tensorflow  # [(osx or linux64) and py<312]
     # Not available on the platforms
     - pytorch  # [not win]
     # transformers tests require pytorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  # s390x: numba not available
+  skip: true  # [py<39 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,10 @@ requirements:
     - slicer ==0.0.8
     - numba
     - cloudpickle
+  run_constrained:
+    # scaled_dot_product_attention attribute is only available
+    # with a newer version of pytorch (>=2.0).
+    - pytorch >=2.0
 
 test:
   requires:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-xorg-x11-server-Xorg


### PR DESCRIPTION
shap 0.46.0

**Destination channel:** defaults

### Links

- [PKG-5654]
- dev_url (pypi): https://github.com/shap/shap/tree/v0.46.0
- diff: https://github.com/shap/shap/compare/v0.45.1...v0.46.0
- conda-forge: https://github.com/conda-forge/shap-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/shap/0.46.0
- pypi inspector: https://inspector.pypi.io/project/shap/0.46.0

### Explanation of changes:

- bump to 0.46.0
- add upstream tests (not all the test dependencies are available, but are optional)
- delete `recipe/yum_requirements.txt`


[PKG-5654]: https://anaconda.atlassian.net/browse/PKG-5654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ