### PR TITLE
shap 0.51.0: add CUDA 12.9 + 13.0 variants (PKG-13210)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,21 @@
+@echo on
+
+if "%gpu_variant%"=="cuda" (
+    REM shap setup.py invokes nvcc directly; point it at the conda CUDA toolkit.
+    set "CUDA_HOME=%BUILD_PREFIX%\Library"
+    set "CUDA_PATH=%BUILD_PREFIX%\Library"
+    set "CUDAToolkit_ROOT=%BUILD_PREFIX%\Library"
+    REM CUDA 13 dropped sm_5x/6x/70/72; older toolkits keep the broader list.
+    REM CUDA 13: Turing through Blackwell incl. B100/B200, RTX 50, DGX Spark.
+    REM CUDA 12: Pascal through Hopper.
+    if "%cuda_compiler_version:~0,2%"=="13" (
+        set "SHAP_CUDA_ARCHITECTURES=75;80;86;89;90;100;103;120;121"
+    ) else (
+        set "SHAP_CUDA_ARCHITECTURES=60;70;75;80;86;89;90"
+    )
+    REM Fail the build if the CUDA extension can't be compiled (no silent CPU fallback).
+    set "SHAP_REQUIRE_CUDA=1"
+)
+
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit /b 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+if [ "${gpu_variant}" = "cuda" ]; then
+    # The shap setup.py invokes nvcc directly; surface our host C++ compiler so
+    # nvcc uses the conda toolchain rather than whatever it finds on PATH.
+    export NVCC_PREPEND_FLAGS="-ccbin ${CXX}"
+    export CUDA_HOME="${CUDA_HOME:-${BUILD_PREFIX}}"
+    export CUDA_PATH="${CUDA_HOME}"
+    case "${cuda_compiler_version}" in
+        13*)
+            # CUDA 13 dropped Maxwell/Pascal/Volta (sm_5x/6x/70/72).
+            # Covers Turing, Ampere, Ada, Hopper, Blackwell (B100/B200, RTX 50, DGX Spark).
+            export SHAP_CUDA_ARCHITECTURES="75;80;86;89;90;100;103;120;121"
+            ;;
+        *)
+            # Covers Pascal, Volta, Turing, Ampere, Ada, Hopper.
+            export SHAP_CUDA_ARCHITECTURES="60;70;75;80;86;89;90"
+            ;;
+    esac
+    # Fail the build if the CUDA extension can't be compiled (no silent CPU fallback).
+    export SHAP_REQUIRE_CUDA=1
+fi
+
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,20 @@
+# Local CBC: add gpu_variant zip alongside cuda_compiler_version so a single
+# meta.yaml produces a CPU build plus CUDA 12.9 and 13.0 builds on platforms
+# where CUDA is available (linux-64, linux-aarch64, win-64).
+gpu_variant:
+  - none
+  - cuda                         # [linux or (win and x86_64)]
+  - cuda                         # [linux or (win and x86_64)]
+
+cuda_compiler:                   # [linux or (win and x86_64)]
+  - cuda-nvcc                    # [linux or (win and x86_64)]
+
+cuda_compiler_version:           # [linux or (win and x86_64)]
+  - none                         # [linux or (win and x86_64)]
+  - 12.9                         # [linux or (win and x86_64)]
+  - 13.0                         # [linux or (win and x86_64)]
+
+zip_keys:
+  -                              # [linux or (win and x86_64)]
+    - gpu_variant                # [linux or (win and x86_64)]
+    - cuda_compiler_version      # [linux or (win and x86_64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,11 @@ requirements:
 # passes. The binary-classifier parametrization passes for the same code path. Shap's
 # own CI runs without a GPU so the bug was never caught upstream.
 {% set deselect_tests_cuda = " --deselect=tests/explainers/test_gpu_tree.py::test_gpu_tree_explainer_shap_interactions[tree_path_dependent-xgboost.sklearn.XGBClassifier1]" %}
+# win-64 CUDA only: XGBRFClassifier additivity check drifts beyond np.allclose's
+# default tolerance. The CPU TreeExplainer traverses on CPU but xgboost auto-uses
+# the worker's GPU for the RandomForest predict, so bagging accumulates FP drift.
+# Single-tree XGBClassifier passes on the same worker; linux-64 CUDA passes for both.
+{% set deselect_tests_cuda_win = " --deselect=tests/explainers/test_tree.py::TestExplainerXGBoost::test_xgboost_dmatrix_propagation[XGBRFClassifier]" %}
 
 {% set ignore_tests = "" %}
 # Skip 3.14 test for now due to massive failing scope because of
@@ -127,8 +132,9 @@ test:
     # OMP: Error #13: Assertion failure at kmp_dispatch.cpp(1298).
     # https://github.com/llvm/llvm-project/issues/54422
     - export OMP_NUM_THREADS=1  # [osx]
-    - pytest -sv tests {{ deselect_tests }} {{ ignore_tests }} --ignore=tests/benchmark                                # [gpu_variant != "cuda"]
-    - pytest -sv tests {{ deselect_tests }} {{ deselect_tests_cuda }} {{ ignore_tests }} --ignore=tests/benchmark      # [gpu_variant == "cuda"]
+    - pytest -sv tests {{ deselect_tests }} {{ ignore_tests }} --ignore=tests/benchmark                                                         # [gpu_variant != "cuda"]
+    - pytest -sv tests {{ deselect_tests }} {{ deselect_tests_cuda }} {{ ignore_tests }} --ignore=tests/benchmark                               # [gpu_variant == "cuda" and not win]
+    - pytest -sv tests {{ deselect_tests }} {{ deselect_tests_cuda }} {{ deselect_tests_cuda_win }} {{ ignore_tests }} --ignore=tests/benchmark  # [gpu_variant == "cuda" and win]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,12 @@ requirements:
 {% set deselect_tests = deselect_tests + " --deselect=tests/explainers/test_coalition.py::test_tabular_coalition_partition_match" %}
 # Flaky on CI: urllib.error.HTTPError: HTTP Error 502: Bad Gateway or Proxy Error
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_datasets.py::test_nhanesi" %}
+# Pre-existing upstream bug in GPU TreeSHAP interaction values for multiclass XGBoost:
+# shap_interaction_values are not additive (sum != model margin) for the multiclass
+# classifier task, although the matching shap_values test (with check_additivity=True)
+# passes. The binary-classifier parametrization passes for the same code path. Shap's
+# own CI runs without a GPU so the bug was never caught upstream.
+{% set deselect_tests_cuda = " --deselect=tests/explainers/test_gpu_tree.py::test_gpu_tree_explainer_shap_interactions[tree_path_dependent-xgboost.sklearn.XGBClassifier1]" %}
 
 {% set ignore_tests = "" %}
 # Skip 3.14 test for now due to massive failing scope because of
@@ -113,7 +119,8 @@ test:
     # OMP: Error #13: Assertion failure at kmp_dispatch.cpp(1298).
     # https://github.com/llvm/llvm-project/issues/54422
     - export OMP_NUM_THREADS=1  # [osx]
-    - pytest -sv tests {{ deselect_tests }} {{ ignore_tests }} --ignore=tests/benchmark
+    - pytest -sv tests {{ deselect_tests }} {{ ignore_tests }} --ignore=tests/benchmark                                # [gpu_variant != "cuda"]
+    - pytest -sv tests {{ deselect_tests }} {{ deselect_tests_cuda }} {{ ignore_tests }} --ignore=tests/benchmark      # [gpu_variant == "cuda"]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,9 @@ requirements:
 {% set deselect_tests = deselect_tests + " --deselect=tests/explainers/test_coalition.py::test_tabular_coalition_partition_match" %}
 # Flaky on CI: urllib.error.HTTPError: HTTP Error 502: Bad Gateway or Proxy Error
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_datasets.py::test_nhanesi" %}
+# Flaky on CI: a1a.svmlight is fetched from a github_data_url that returns HTTP 502 intermittently.
+{% set deselect_tests = deselect_tests + " --deselect=tests/explainers/test_kernel.py::test_kernel_shap_with_a1a_sparse_zero_background" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/explainers/test_kernel.py::test_kernel_shap_with_a1a_sparse_nonzero_background" %}
 # Pre-existing upstream bug in GPU TreeSHAP interaction values for multiclass XGBoost:
 # shap_interaction_values are not additive (sum != model margin) for the multiclass
 # classifier task, although the matching shap_values test (with check_additivity=True)
@@ -90,6 +93,11 @@ requirements:
 {% set ignore_tests = ignore_tests + " --ignore=tests/maskers/test_text.py" %}  # [py==314]
 {% set ignore_tests = ignore_tests + " --ignore=tests/models/test_teacher_forcing_logits.py" %}  # [py==314]
 {% set ignore_tests = ignore_tests + " --ignore=tests/models/test_text_generation.py" %}  # [py==314]
+# pkgs/main pytorch on linux-aarch64 is missing GPU kernels for the PBP cuda worker
+# (torch.AcceleratorError: cudaErrorNoKernelImageForDevice). test_deep.py's CUDA-device
+# parametrizations all fail; CPU-device ones pass. Skip the file on this combo until
+# pytorch ships aarch64-cuda binaries covering the worker's compute capability.
+{% set ignore_tests = ignore_tests + " --ignore=tests/explainers/test_deep.py" %}  # [aarch64 and gpu_variant == "cuda"]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "shap" %}
 {% set version = "0.51.0" %}
+{% set build_number = 1 %}
 
 package:
   name: {{ name|lower }}
@@ -8,17 +9,30 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: cfa17ff213657c9d50285aa923d79b0037a62e2ee1a31bc3eec7e196b00bdb59
+  patches:
+    - patches/cuda-arch-env-and-hard-fail.patch  # [gpu_variant == "cuda"]
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: {{ build_number + 100 }}  # [gpu_variant == "cuda"]
+  number: {{ build_number }}        # [gpu_variant != "cuda"]
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
+  string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant != "cuda"]
   skip: true  # [py<311]
+  skip: true  # [ppc64le]
+  # CUDA compiler run_exports tight-pin cuda-version; we pin cuda-version
+  # explicitly via pin_compatible(min_pin='x') for forward compat within the major.
+  ignore_run_exports_from:                # [gpu_variant == "cuda"]
+    - {{ compiler('cuda') }}              # [gpu_variant == "cuda"]
+  missing_dso_whitelist:                  # [gpu_variant == "cuda"]
+    - "**/libcuda.so*"                    # [gpu_variant == "cuda" and not win]
+    - "**/nvcuda.dll"                     # [gpu_variant == "cuda" and win]
 
 requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }}              # [gpu_variant == "cuda"]
   host:
     - python
     - pip
@@ -28,6 +42,8 @@ requirements:
     - numpy {{ numpy }}
     - packaging >=20.9
     - cython >=3.0.11
+    - cuda-version {{ cuda_compiler_version }}   # [gpu_variant == "cuda"]
+    - cuda-cudart-dev                            # [gpu_variant == "cuda"]
   run:
     - python
     - numpy >=2
@@ -44,6 +60,8 @@ requirements:
     # https://github.com/conda-forge/shap-feedstock/blob/main/recipe/recipe.yaml#L64-L66
     - cloudpickle
     - typing-extensions
+    - {{ pin_compatible('cuda-version', min_pin='x') }}   # [gpu_variant == "cuda"]
+    - __cuda                                              # [gpu_variant == "cuda"]
 
 # E numpy._core._exceptions._ArrayMemoryError: Unable to allocate 16.4 GiB for an array with shape (2000, 1100000) and data type float64
 {% set deselect_tests = " --deselect=tests/explainers/test_tree.py::test_overflow_tree_path_dependent" %}
@@ -89,6 +107,7 @@ test:
     - shap.utils
     - shap.utils._exceptions
     - shap.utils._masked_model
+    - shap._cext_gpu                                  # [gpu_variant == "cuda"]
   commands:
     - pip check
     # OMP: Error #13: Assertion failure at kmp_dispatch.cpp(1298).

--- a/recipe/patches/cuda-arch-env-and-hard-fail.patch
+++ b/recipe/patches/cuda-arch-env-and-hard-fail.patch
@@ -1,0 +1,58 @@
+From: Xianglong Kong <xkong@anaconda.com>
+Subject: Make NVCC arch list env-controlled, c++17 by default, fail-hard on CUDA build error
+
+Make CUDA arch list configurable via SHAP_CUDA_ARCHITECTURES, bump NVCC
+device-code C++ standard to c++17 (required by CUDA 13.0), and disable the
+silent CPU fallback when SHAP_REQUIRE_CUDA=1 so a CUDA build variant cannot
+accidentally produce a CPU-only artifact.
+
+Note: patch generated with AI assistance.
+
+--- a/setup.py
++++ b/setup.py
+@@ -75,18 +75,25 @@
+     _, nvcc = get_cuda_path()
+
+     print("NVCC ==> ", nvcc)
+-    arch_flags = (
+-        "-gencode=arch=compute_60,code=sm_60 "
+-        "-gencode=arch=compute_70,code=sm_70 "
+-        "-gencode=arch=compute_75,code=sm_75 "
+-        "-gencode=arch=compute_75,code=compute_75 "
+-        "-gencode=arch=compute_80,code=sm_80"
+-    )
++    arch_env = os.environ.get("SHAP_CUDA_ARCHITECTURES", "").strip()
++    if arch_env:
++        archs = [a.strip() for a in arch_env.split(";") if a.strip()]
++        flags = [f"-gencode=arch=compute_{a},code=sm_{a}" for a in archs]
++        flags.append(f"-gencode=arch=compute_{archs[-1]},code=compute_{archs[-1]}")
++        arch_flags = " ".join(flags)
++    else:
++        arch_flags = (
++            "-gencode=arch=compute_60,code=sm_60 "
++            "-gencode=arch=compute_70,code=sm_70 "
++            "-gencode=arch=compute_75,code=sm_75 "
++            "-gencode=arch=compute_75,code=compute_75 "
++            "-gencode=arch=compute_80,code=sm_80"
++        )
+     nvcc_command = (
+         f"-allow-unsupported-compiler shap/cext/_cext_gpu.cu -lib -o {lib_out} "
+         f"-Xcompiler {','.join(host_args)} "
+         f"--include-path {sysconfig.get_path('include')} "
+-        "--std c++14 "
++        "--std c++17 "
+         "--expt-extended-lambda "
+         f"--expt-relaxed-constexpr {arch_flags}"
+     )
+@@ -156,7 +163,10 @@
+     except Exception as e:
+         print("Exception occurred during setup,", str(e))
+
+-        if with_cuda:
++        if with_cuda and os.environ.get("SHAP_REQUIRE_CUDA") == "1":
++            print("ERROR: CUDA build required (SHAP_REQUIRE_CUDA=1) but failed.")
++            raise
++        elif with_cuda:
+             with_cuda = False
+             print("WARNING: Could not compile cuda extensions.")
+             print("Retrying SHAP build without cuda extension...")


### PR DESCRIPTION
shap 0.51.0

**Destination channel:** defaults

### Links

- [PKG-13210](https://anaconda.atlassian.net/browse/PKG-13210)
- [Parent: PKG-13074 — 2026Q2 AI & Growth Packages](https://anaconda.atlassian.net/browse/PKG-13074)
- [Upstream repository](https://github.com/shap/shap)
- [Upstream v0.51.0 tag](https://github.com/shap/shap/tree/v0.51.0)
- [Conda-forge reference recipe](https://github.com/conda-forge/shap-feedstock/blob/main/recipe/recipe.yaml)

### Explanation of changes:

- **Adds CUDA variants** for shap on `linux-64`, `linux-aarch64`, and `win-64` against CUDA `12.9` and `13.0`, per parent epic PKG-13074. CPU build still produced everywhere else (osx-64, osx-arm64, win-arm64). `ppc64le` is skipped.



[PKG-13210]: https://anaconda.atlassian.net/browse/PKG-13210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ